### PR TITLE
api get data customer from database

### DIFF
--- a/sequelize/models/Customer.js
+++ b/sequelize/models/Customer.js
@@ -26,6 +26,8 @@ export default class Customer extends RenchanModel {
     super.associate?.()
 
     this.hasOne(this._.CustomerPasswordHash)
+    this.hasOne(this._.CustomerBasic, { foreignKey: 'CustomerId' })
+    this.hasOne(this._.CustomerSecret, { foreignKey: 'CustomerId' })
   }
 
   /** @override */

--- a/server/graphql/CustomerGraphqlServerEngine.js
+++ b/server/graphql/CustomerGraphqlServerEngine.js
@@ -45,9 +45,9 @@ export default class CustomerGraphqlServerEngine extends BaseAppGraphqlServerEng
     return [
       'companySponsors',
       'curriculums',
-      // 'customer',
-      // 'customerById',
-      // 'customerPagination',
+      'customer',
+      'customerById',
+      'customerPagination',
       'signUp',
       'signIn',
 

--- a/server/graphql/CustomerGraphqlServerEngine.js
+++ b/server/graphql/CustomerGraphqlServerEngine.js
@@ -45,6 +45,9 @@ export default class CustomerGraphqlServerEngine extends BaseAppGraphqlServerEng
     return [
       'companySponsors',
       'curriculums',
+      // 'customer',
+      // 'customerById',
+      // 'customerPagination',
       'signUp',
       'signIn',
 

--- a/server/graphql/resolvers/customer/actual/queries/CustomerQueryByIdResolver.js
+++ b/server/graphql/resolvers/customer/actual/queries/CustomerQueryByIdResolver.js
@@ -1,0 +1,45 @@
+import {
+  BaseQueryResolver,
+} from '@openreachtech/renchan'
+import Customer from '../../../../../../sequelize/models/Customer.js';
+import CustomerBasic from '../../../../../../sequelize/models/CustomerBasic.js';
+import CustomerSecret from '../../../../../../sequelize/models/CustomerSecret.js';
+
+export default class CustomerQueryResolver extends BaseQueryResolver {
+  /** @override */
+  static get schema () {
+    return 'customerById'
+  }
+
+  /** @override */
+  async resolve({ variables }) {
+    const { id } = variables || {};
+
+    const [customer, customerBasic, customerSecret] = await Promise.all([
+      Customer.findOne({
+        where: {
+          id : id,
+        },
+      }),
+      CustomerBasic.findOne({
+        where: {
+          CustomerId: id,
+        },
+      }),
+      CustomerSecret.findOne({
+        where: {
+          CustomerId: id,
+        },
+      }),
+    ])
+    
+    const data = {
+      id: customer.id,
+      username: customerBasic.username,
+      email: customerSecret.email,
+      registeredAt: customer.registeredAt,
+    }
+    
+    return data
+   }
+}

--- a/server/graphql/resolvers/customer/actual/queries/CustomerQueryByIdResolver.js
+++ b/server/graphql/resolvers/customer/actual/queries/CustomerQueryByIdResolver.js
@@ -4,8 +4,9 @@ import {
 import Customer from '../../../../../../sequelize/models/Customer.js';
 import CustomerBasic from '../../../../../../sequelize/models/CustomerBasic.js';
 import CustomerSecret from '../../../../../../sequelize/models/CustomerSecret.js';
+import CustomerQueryResolver from './CustomerQueryResolver.js';
 
-export default class CustomerQueryResolver extends BaseQueryResolver {
+export default class CustomerQueryByIdResolver extends BaseQueryResolver {
   /** @override */
   static get schema () {
     return 'customerById'
@@ -15,30 +16,9 @@ export default class CustomerQueryResolver extends BaseQueryResolver {
   async resolve({ variables }) {
     const { id } = variables || {};
 
-    const [customer, customerBasic, customerSecret] = await Promise.all([
-      Customer.findOne({
-        where: {
-          id : id,
-        },
-      }),
-      CustomerBasic.findOne({
-        where: {
-          CustomerId: id,
-        },
-      }),
-      CustomerSecret.findOne({
-        where: {
-          CustomerId: id,
-        },
-      }),
-    ])
-    
-    const data = {
-      id: customer.id,
-      username: customerBasic.username,
-      email: customerSecret.email,
-      registeredAt: customer.registeredAt,
-    }
+    const customer = await CustomerQueryResolver.findCustomerDetail(id);
+
+    const data = CustomerQueryResolver.formatCustomerDetail(customer);
     
     return data
    }

--- a/server/graphql/resolvers/customer/actual/queries/CustomerQueryPaginationResolver.js
+++ b/server/graphql/resolvers/customer/actual/queries/CustomerQueryPaginationResolver.js
@@ -5,56 +5,44 @@ import Customer from '../../../../../../sequelize/models/Customer.js';
 import CustomerBasic from '../../../../../../sequelize/models/CustomerBasic.js';
 import CustomerSecret from '../../../../../../sequelize/models/CustomerSecret.js';
 
-export default class CustomerQueryResolver extends BaseQueryResolver {
+export default class CustomerQueryPaginationResolver extends BaseQueryResolver {
   /** @override */
   static get schema () {
     return 'customerPagination'
   }
 
+  async paginateCustomers({ page = 1, limit = 10 }) {
+  const offset = (page - 1) * limit;
+
+  const { count, rows: customers } = await Customer.findAndCountAll({
+    offset,
+    limit,
+    order: [['registeredAt', 'DESC']],
+    include: [
+      { model: CustomerBasic, attributes: ['username'] },
+      { model: CustomerSecret, attributes: ['email'] },
+    ],
+  });
+
+  const data = customers.map(c => ({
+    id: c.get('id'),
+    username: c.get('CustomerBasic')?.get('username') ?? null,
+    email: c.get('CustomerSecret')?.get('email') ?? null,
+    registeredAt: c.get('registeredAt'),
+  }));
+
+  return {
+    data,
+    total: count,
+    page,
+    limit,
+    totalPages: Math.ceil(count / limit),
+  };
+}
   /** @override */
-  async resolve({variables}) {
-    const { page, limit = 10 } = variables.customerPaginationInput || {};
-    const offset = (page - 1) * limit;
-
-    const { count, rows: customers } = await Customer.findAndCountAll({
-      offset,
-      limit,
-      order: [['registeredAt', 'DESC']],
-    });
-
-    const customerIds = customers.map(c => c.get('id'));
-
-    const [basics, secrets] = await Promise.all([
-      CustomerBasic.findAll({
-        where: { CustomerId: customerIds },
-      }),
-      CustomerSecret.findAll({
-        where: { CustomerId: customerIds },
-      }),
-    ]);
-
-    const data = customers.map(c => {
-      const id = c.get('id');
-      const basic = basics.find(b => b.get('CustomerId') === id);
-      const secret = secrets.find(s => s.get('CustomerId') === id);
-
-      return {
-        id,
-        username: basic?.get('username') ?? null,
-        email: secret?.get('email') ?? null,
-        registeredAt: c.get('registeredAt'),
-      };
-    });
-
-    const total = Math.ceil(count / limit);
-
-    return {
-      data,
-      total: count,
-      page,
-      limit,
-      totalPages: total,
-    };
+  async resolve({ variables }) {
+    const { page = 1, limit = 10 } = variables.customerPaginationInput || {};
+    return this.paginateCustomers({ page, limit });
   }
 
 }

--- a/server/graphql/resolvers/customer/actual/queries/CustomerQueryPaginationResolver.js
+++ b/server/graphql/resolvers/customer/actual/queries/CustomerQueryPaginationResolver.js
@@ -1,0 +1,60 @@
+import {
+  BaseQueryResolver,
+} from '@openreachtech/renchan'
+import Customer from '../../../../../../sequelize/models/Customer.js';
+import CustomerBasic from '../../../../../../sequelize/models/CustomerBasic.js';
+import CustomerSecret from '../../../../../../sequelize/models/CustomerSecret.js';
+
+export default class CustomerQueryResolver extends BaseQueryResolver {
+  /** @override */
+  static get schema () {
+    return 'customerPagination'
+  }
+
+  /** @override */
+  async resolve({variables}) {
+    const { page, limit = 10 } = variables.customerPaginationInput || {};
+    const offset = (page - 1) * limit;
+
+    const { count, rows: customers } = await Customer.findAndCountAll({
+      offset,
+      limit,
+      order: [['registeredAt', 'DESC']],
+    });
+
+    const customerIds = customers.map(c => c.get('id'));
+
+    const [basics, secrets] = await Promise.all([
+      CustomerBasic.findAll({
+        where: { CustomerId: customerIds },
+      }),
+      CustomerSecret.findAll({
+        where: { CustomerId: customerIds },
+      }),
+    ]);
+
+    const data = customers.map(c => {
+      const id = c.get('id');
+      const basic = basics.find(b => b.get('CustomerId') === id);
+      const secret = secrets.find(s => s.get('CustomerId') === id);
+
+      return {
+        id,
+        username: basic?.get('username') ?? null,
+        email: secret?.get('email') ?? null,
+        registeredAt: c.get('registeredAt'),
+      };
+    });
+
+    const total = Math.ceil(count / limit);
+
+    return {
+      data,
+      total: count,
+      page,
+      limit,
+      totalPages: total,
+    };
+  }
+
+}

--- a/server/graphql/resolvers/customer/actual/queries/CustomerQueryResolver.js
+++ b/server/graphql/resolvers/customer/actual/queries/CustomerQueryResolver.js
@@ -1,12 +1,36 @@
 import {
   BaseQueryResolver,
 } from '@openreachtech/renchan'
+import Customer from '../../../../../../sequelize/models/Customer.js'
+import CustomerBasic from '../../../../../../sequelize/models/CustomerBasic.js'
+import CustomerSecret from '../../../../../../sequelize/models/CustomerSecret.js'
 
 export default class CustomerQueryResolver extends BaseQueryResolver {
   /** @override */
   static get schema () {
     return 'customer'
   }
+
+  static async findCustomerDetail(id) {
+    return Customer.findOne({
+      where: { id },
+      include: [
+        { model: CustomerBasic, attributes: ['username'] },
+        { model: CustomerSecret, attributes: ['email'] },
+      ],
+      attributes: ['id', 'registeredAt'],
+    })
+  }
+
+  static async formatCustomerDetail(customerDetail) {
+    return {
+      id: customerDetail.id,
+      username: customerDetail.CustomerBasic.username,
+      email: customerDetail.CustomerSecret.email,
+      registeredAt: customerDetail.registeredAt,
+    }
+  }
+
 
   /** @override */
   async resolve () {

--- a/server/graphql/schemas/customer.graphql
+++ b/server/graphql/schemas/customer.graphql
@@ -7,9 +7,23 @@ scalar Upload
 ################################################################################
 
 ## !!!!!!!! Please add in dictionary order.
+type PaginatedCustomers {
+  data: [Customer!]!
+  total: Int!
+  page: Int!
+  limit: Int!
+  totalPages: Int!
+}
+
+input  CustomerPaginationInput {
+  page: Int
+  limit: Int
+}
 
 type Query {
   customer: Customer!
+  customerById(id: Int!): Customer!
+  customerPagination(customerPaginationInput : CustomerPaginationInput): PaginatedCustomers!
   payments: [Payment!]!
 
   # for furo boilerplate -------------------------------------------------------
@@ -65,8 +79,9 @@ type AuthResult {
 
 type Customer {
   id: Int!
-  inviteCode: String!
   username: String!
+  email: String!
+  registeredAt: String!
 
   CustomerDetail: CustomerDetail
 }

--- a/test-customer-resolver.js
+++ b/test-customer-resolver.js
@@ -1,0 +1,34 @@
+import http from 'http';
+
+const postData = JSON.stringify({
+  query: 'query Customer { customer { id username inviteCode CustomerDetail { email } } }'
+});
+
+const options = {
+  hostname: 'localhost',
+  port: 3900,
+  path: '/graphql-customer',
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(postData)
+  }
+};
+
+const req = http.request(options, (res) => {
+  console.log(`statusCode: ${res.statusCode}`);
+  console.log(`headers:`, res.headers);
+
+  res.on('data', (d) => {
+    process.stdout.write(d);
+  });
+});
+
+req.on('error', (error) => {
+  console.error(error);
+});
+
+req.write(postData);
+req.end();
+
+

--- a/tests/__tests__/server/graphql/resolvers/customer/actual/queries/CustomerQueryByIdResolver.js
+++ b/tests/__tests__/server/graphql/resolvers/customer/actual/queries/CustomerQueryByIdResolver.js
@@ -1,0 +1,109 @@
+import { jest } from '@jest/globals'
+import CustomerQueryByIdResolver from '../../../../../../../../server/graphql/resolvers/customer/actual/queries/CustomerQueryByIdResolver.js'
+import CustomerQueryResolver from '../../../../../../../../server/graphql/resolvers/customer/actual/queries/CustomerQueryResolver.js'
+
+describe('CustomerQueryByIdResolver', () => {
+  describe('.get:schema', () => {
+    test('to be fixed value', () => {
+      const actual = CustomerQueryByIdResolver.schema
+
+      expect(actual)
+        .toBe('customerById')
+    })
+  })
+})
+
+describe('CustomerQueryByIdResolver', () => {
+  describe('#resolve()', () => {
+    beforeEach(() => {
+      jest.spyOn(CustomerQueryResolver, 'findCustomerDetail').mockClear()
+      jest.spyOn(CustomerQueryResolver, 'formatCustomerDetail').mockClear()
+    })
+
+    describe('with existing customer id', () => {
+      const cases = [
+        {
+          params: {
+            variables: { id: 100001 },
+          },
+          mockCustomer: {
+            id: 100001,
+            registeredAt: new Date('2024-01-01T00:00:01.001Z'),
+            CustomerBasic: {
+              username: 'customerName01',
+            },
+            CustomerSecret: {
+              email: 'customer.100001@example.com',
+            },
+          },
+          expected: {
+            id: 100001,
+            username: 'customerName01',
+            email: 'customer.100001@example.com',
+            registeredAt: new Date('2024-01-01T00:00:01.001Z'),
+          },
+        },
+        {
+          params: {
+            variables: { id: 100002 },
+          },
+          mockCustomer: {
+            id: 100002,
+            registeredAt: new Date('2024-01-02T00:00:02.002Z'),
+            CustomerBasic: {
+              username: 'customerName02',
+            },
+            CustomerSecret: {
+              email: 'customer.100002@example.com',
+            },
+          },
+          expected: {
+            id: 100002,
+            username: 'customerName02',
+            email: 'customer.100002@example.com',
+            registeredAt: new Date('2024-01-02T00:00:02.002Z'),
+          },
+        },
+      ]
+
+      test.each(cases)('id: $params.variables.id', async ({ params, mockCustomer, expected }) => {
+        // jest.spyOn(CustomerQueryResolver, 'findCustomerDetail').mockResolvedValue(Promise.resolve(mockCustomer))
+        // jest.spyOn(CustomerQueryResolver, 'formatCustomerDetail').mockReturnValue(Promise.resolve(expected))
+
+        const resolver = new CustomerQueryByIdResolver()
+        const actual = await resolver.resolve(params)
+
+        // expect(CustomerQueryResolver.findCustomerDetail).toHaveBeenCalledWith(params.variables.id)
+        // expect(CustomerQueryResolver.formatCustomerDetail).toHaveBeenCalledWith(mockCustomer)
+        expect(actual).toEqual(expected)
+      })
+    })
+
+    describe('with non-existing customer id', () => {
+      const cases = [
+        {
+          params: {
+            variables: { id: 999998 },
+          },
+        },
+        {
+          params: {
+            variables: { id: 999999 },
+          },
+        },
+      ]
+
+      test.each(cases)('id: $params.variables.id', async ({ params }) => {
+        jest.spyOn(CustomerQueryResolver, 'findCustomerDetail').mockResolvedValue(null)
+        jest.spyOn(CustomerQueryResolver, 'formatCustomerDetail').mockReturnValue(null)
+
+        const resolver = new CustomerQueryByIdResolver()
+        const actual = await resolver.resolve(params)
+
+        expect(CustomerQueryResolver.findCustomerDetail).toHaveBeenCalledWith(params.variables.id)
+        expect(CustomerQueryResolver.formatCustomerDetail).toHaveBeenCalledWith(null)
+        expect(actual).toBeNull()
+      })
+    })
+  })
+})

--- a/tests/__tests__/server/graphql/resolvers/customer/actual/queries/CustomerQueryResolver.js
+++ b/tests/__tests__/server/graphql/resolvers/customer/actual/queries/CustomerQueryResolver.js
@@ -1,0 +1,142 @@
+import CustomerQueryResolver from '../../../../../../../../server/graphql/resolvers/customer/actual/queries/CustomerQueryResolver.js'
+import Customer from '../../../../../../../../sequelize/models/Customer.js'
+import CustomerBasic from '../../../../../../../../sequelize/models/CustomerBasic.js'
+import CustomerSecret from '../../../../../../../../sequelize/models/CustomerSecret.js'
+
+describe('CustomerQueryResolver', () => {
+  describe('.get:schema', () => {
+    test('to be fixed value', () => {
+      const actual = CustomerQueryResolver.schema
+
+      expect(actual)
+        .toBe('customer')
+    })
+  })
+})
+
+describe('CustomerQueryResolver', () => {
+  describe('#findCustomerDetail()', () => {
+    describe('with existing customer id', () => {
+      const cases = [
+        {
+          params: {
+            id: 100001,
+          },
+          expected: {
+            id: 100001,
+            registeredAt: new Date('2024-01-01T00:00:01.001Z'),
+            CustomerBasic: {
+              username: 'customerName01',
+            },
+            CustomerSecret: {
+              email: 'customer.100001@example.com',
+            },
+          },
+        },
+        {
+          params: {
+            id: 100002,
+          },
+          expected: {
+            id: 100002,
+            registeredAt: new Date('2024-01-02T00:00:02.002Z'),
+            CustomerBasic: {
+              username: 'customerName02',
+            },
+            CustomerSecret: {
+              email: 'customer.100002@example.com',
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('id: $params.id', async ({ params, expected }) => {
+        const actual = await CustomerQueryResolver.findCustomerDetail(params.id)
+
+        expect(actual).toBeDefined()
+        expect(actual.id).toBe(expected.id)
+        expect(actual.registeredAt).toEqual(expected.registeredAt)
+        expect(actual.CustomerBasic).toBeDefined()
+        expect(actual.CustomerBasic.username).toBe(expected.CustomerBasic.username)
+        expect(actual.CustomerSecret).toBeDefined()
+        expect(actual.CustomerSecret.email).toBe(expected.CustomerSecret.email)
+      })
+    })
+
+    describe('with non-existing customer id', () => {
+      const cases = [
+        {
+          params: {
+            id: 999998,
+          },
+        },
+        {
+          params: {
+            id: 999999,
+          },
+        },
+      ]
+
+      test.each(cases)('id: $params.id', async ({ params }) => {
+        const actual = await CustomerQueryResolver.findCustomerDetail(params.id)
+
+        expect(actual)
+          .toBeNull()
+      })
+    })
+  })
+})
+
+describe('CustomerQueryResolver', () => {
+  describe('#formatCustomerDetail()', () => {
+    const cases = [
+      {
+        params: {
+          customerDetail: {
+            id: 100001,
+            registeredAt: new Date('2024-01-01T00:00:01.001Z'),
+            CustomerBasic: {
+              username: 'customerName01',
+            },
+            CustomerSecret: {
+              email: 'customer.100001@example.com',
+            },
+          },
+        },
+        expected: {
+          id: 100001,
+          username: 'customerName01',
+          email: 'customer.100001@example.com',
+          registeredAt: new Date('2024-01-01T00:00:01.001Z'),
+        },
+      },
+      {
+        params: {
+          customerDetail: {
+            id: 100002,
+            registeredAt: new Date('2024-01-02T00:00:02.002Z'),
+            CustomerBasic: {
+              username: 'customerName02',
+            },
+            CustomerSecret: {
+              email: 'customer.100002@example.com',
+            },
+          },
+        },
+        expected: {
+          id: 100002,
+          username: 'customerName02',
+          email: 'customer.100002@example.com',
+          registeredAt: new Date('2024-01-02T00:00:02.002Z'),
+        },
+      },
+    ]
+
+    test.each(cases)('id: $params.customerDetail.id', async ({ params, expected }) => {
+      const actual = await CustomerQueryResolver.formatCustomerDetail(params.customerDetail)
+
+      expect(actual)
+        .toEqual(expected)
+    })
+  })
+})


### PR DESCRIPTION
# Why
The GraphQL `customer` query currently returns only hardcoded data. 
We need to support two new query types:
1. Query customer by `id`.
2. Query customers with pagination.

This allows us to fetch real data from the database instead of mock data.

# How
- Update `CustomerResolver` to implement `customerById(id: ID!)` query.
- Update `CustomerResolver` to implement `customersPaginated(page: Int, limit: Int)` query.
- Replace hardcoded responses with database queries.
- Update customer schema 

* Close #000
https://chiho-internal.openreach.tech/tasks/6277

